### PR TITLE
fix(rules): fix colliding rules

### DIFF
--- a/src/ionActionSheetMethodCreateParametersRenamedRule.ts
+++ b/src/ionActionSheetMethodCreateParametersRenamedRule.ts
@@ -1,5 +1,5 @@
 import * as Lint from 'tslint';
-import { IOptions, Replacement } from 'tslint';
+import { Replacement } from 'tslint';
 import * as ts from 'typescript';
 
 export const ruleName = 'ion-action-sheet-method-create-parameters-renamed';
@@ -8,23 +8,23 @@ export const ruleName = 'ion-action-sheet-method-create-parameters-renamed';
  * This rule helps with the conversion of the ActionSheetController API.
  */
 class ActionSheetMethodCreateParametersRenamedWalker extends Lint.RuleWalker {
-  //actionControllerVariableName = undefined;
-  foundPropertyArray = [];
+  private details = {
+    actionControllerVariableName: '',
+    foundPropertyArray: []
+  };
 
-  // TODO: Not sure if we need to track the name of the ActionSheetController variable.
-  // visitConstructorDeclaration(node: ts.ConstructorDeclaration) {
-  //   debugger;
-  //   for (let element of node.parameters) {
-  //     const typeName = (element.type as any).typeName.text;
-  //     if (typeName === 'ActionSheetController') {
-  //       this.actionControllerVariableName = (element.name as any).text;
-  //       this.tryAddFailure();
-  //       break;
-  //     }
-  //   }
+  visitConstructorDeclaration(node: ts.ConstructorDeclaration) {
+    debugger;
 
-  //   super.visitConstructorDeclaration(node);
-  // }
+    for (let element of node.parameters) {
+      const typeName = element.type.getFullText().trim();
+      if (typeName === 'ActionSheetController') {
+        this.details.actionControllerVariableName = (element.name as any).escapedText;
+        this.tryAddFailure();
+        break;
+      }
+    }
+  }
 
   visitCallExpression(node: ts.CallExpression) {
     const expression = node.expression as any;
@@ -37,7 +37,7 @@ class ActionSheetMethodCreateParametersRenamedWalker extends Lint.RuleWalker {
           case 'title':
           case 'subTitle':
             argument.parentVariableName = (node.expression as any).expression.text;
-            this.foundPropertyArray.push(argument);
+            this.details.foundPropertyArray.push(argument);
             this.tryAddFailure();
             break;
         }
@@ -46,21 +46,26 @@ class ActionSheetMethodCreateParametersRenamedWalker extends Lint.RuleWalker {
   }
 
   private tryAddFailure() {
-    for (let i = this.foundPropertyArray.length - 1; i >= 0; i--) {
-      let argument = this.foundPropertyArray[i];
+    // Don't process until the actionControllerVariableName has been found
+
+    if (!this.details.actionControllerVariableName) {
+      return;
+    }
+
+    for (let i = this.details.foundPropertyArray.length - 1; i >= 0; i--) {
+      let argument = this.details.foundPropertyArray[i];
 
       const replacementParam = argument.name.text === 'title' ? 'header' : 'subHeader';
 
-      // TODO: Determine if this needs to be added in later.
-      //if (this.actionControllerVariableName && this.actionControllerVariableName === argument.parentVariableName) {
-      const errorMessage = `The ${argument.name.text} field has been replaced by ${replacementParam}.`;
+      console.log(this.details.actionControllerVariableName, argument.parentVariableName);
+      if (this.details.actionControllerVariableName && this.details.actionControllerVariableName === argument.parentVariableName) {
+        const errorMessage = `The ${argument.name.text} field has been replaced by ${replacementParam}.`;
 
-      const replacement = new Replacement(argument.name.getStart(), argument.name.getWidth(), replacementParam);
+        const replacement = new Replacement(argument.name.getStart(), argument.name.getWidth(), replacementParam);
 
-      this.addFailure(this.createFailure(argument.name.getStart(), argument.name.getWidth(), errorMessage, [replacement]));
-      this.foundPropertyArray.splice(i, 1);
-
-      //}
+        this.addFailure(this.createFailure(argument.name.getStart(), argument.name.getWidth(), errorMessage, [replacement]));
+        this.details.foundPropertyArray.splice(i, 1);
+      }
     }
   }
 }

--- a/test/ionActionSheetMethodCreateParametersRenamed.spec.ts
+++ b/test/ionActionSheetMethodCreateParametersRenamed.spec.ts
@@ -22,6 +22,25 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source);
     });
 
+    it('should not be triggered if the type is not ActionSheetController', () => {
+      debugger;
+
+      let source = `
+      class DoSomething{
+        constructor(private actionSheetCtrl: SomeOtherController){}
+
+        function showActionSheet(){
+          const actionSheet = await actionSheetCtrl.create({
+            title: 'This is the title',
+            subTitle: 'this is the sub title'
+          });
+          await actionSheet.present();
+        }
+      }
+        `;
+      assertSuccess(ruleName, source);
+    });
+
     it('should work with different names for the ActionSheetController object', () => {
       let source = `
       class DoSomething{
@@ -44,7 +63,9 @@ describe(ruleName, () => {
     it('should fail when title is passed in', () => {
       let source = `
       class DoSomething{
-        constructor(private actionSheetCtrl: ActionSheetController){}
+        constructor(private actionSheetCtrl: ActionSheetController){
+
+        }
 
         function showActionSheet(){
           const actionSheet = await actionSheetCtrl.create({
@@ -77,29 +98,6 @@ describe(ruleName, () => {
           });
           await actionSheet.present();
         }
-      }
-          `;
-
-      assertAnnotated({
-        ruleName,
-        message: 'The subTitle field has been replaced by subHeader.',
-        source
-      });
-    });
-
-    it('should fail no matter where the constructor is placed in code', () => {
-      let source = `
-      class DoSomething{
-        function showActionSheet(){
-          const actionSheet = await actionSheetCtrl.create({
-            header: 'This is the title',            
-            subTitle: 'this is the sub title'            
-            ~~~~~~~~
-          });
-          await actionSheet.present();
-        }
-
-        constructor(private actionSheetCtrl: ActionSheetController){}
       }
           `;
 

--- a/test/ionAlertMethodCreateParametersRenamed.spec.ts
+++ b/test/ionAlertMethodCreateParametersRenamed.spec.ts
@@ -22,6 +22,25 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source);
     });
 
+    it('should not be triggered if the type is not AlertController', () => {
+      debugger;
+
+      let source = `
+      class DoSomething{
+        constructor(private actionSheetCtrl: SomeOtherController){}
+
+        function showActionSheet(){
+          const actionSheet = await actionSheetCtrl.create({
+            title: 'This is the title',
+            subTitle: 'this is the sub title'
+          });
+          await actionSheet.present();
+        }
+      }
+        `;
+      assertSuccess(ruleName, source);
+    });
+
     it('should work with different names for the AlertController object', () => {
       let source = `
       class DoSomething{
@@ -77,29 +96,6 @@ describe(ruleName, () => {
           });
           await alert.present();
         }
-      }
-          `;
-
-      assertAnnotated({
-        ruleName,
-        message: 'The subTitle field has been replaced by subHeader.',
-        source
-      });
-    });
-
-    it('should fail no matter where the constructor is placed in code', () => {
-      let source = `
-      class DoSomething{
-        function showAlert(){
-          const alert = await alertCtrl.create({
-            header: 'This is the title',            
-            subTitle: 'this is the sub title'            
-            ~~~~~~~~
-          });
-          await alert.present();
-        }
-
-        constructor(private alertCtrl: AlertController){}
       }
           `;
 


### PR DESCRIPTION
@dwieeb , this fixes #17 but comes with a caveat. For some reason, TSLint will not parse a constructor if it is placed after any other function declarations. Because of this, if the constructor is after a method that calls the `create` method, it will not fire. Do we assume that people are following the standard convention of having the constructor at the top of their class?