### PR TITLE
fix(rules): fix colliding rules 

### DIFF
--- a/src/helpers/parametersRenamed.ts
+++ b/src/helpers/parametersRenamed.ts
@@ -1,0 +1,94 @@
+import * as Lint from 'tslint';
+import * as ts from 'typescript';
+import * as tsutils from 'tsutils';
+
+/**
+ * Currently only supports a call exactly like this:
+ *
+ * ```
+ * this.ctrl.foo({ prop1: <value>, prop2: <value> })
+ * ```
+ *
+ * `this.ctrl` must refer to a provider by name in the constructor of a class
+ * using Angular dependency injection
+ *
+ * @param methodName would be `foo` in example above
+ * @param providerName the provider class name
+ * @param parameterMap a map of properties to rename in the object literal above
+ */
+export function createParametersRenamedClass(methodName: string, providerName: string, parameterMap: Map<string, string>) {
+  return class extends Lint.RuleWalker {
+    visitCallExpression(node: ts.CallExpression) {
+      debugger;
+      if (node.arguments.length > 0) {
+        const firstArgument = node.arguments[0];
+
+        if (isValidForRule(node, methodName, providerName) && tsutils.isObjectLiteralExpression(firstArgument)) {
+          for (const prop of firstArgument.properties) {
+            if (tsutils.isPropertyAssignment(prop)) {
+              const propName = tsutils.getPropertyName(prop.name);
+              const replacement = parameterMap.get(propName);
+
+              if (replacement) {
+                this.addFailureAtNode(
+                  prop.name,
+                  `Property ${propName} has been renamed to ${replacement}.`,
+                  new Lint.Replacement(prop.name.getStart(), prop.name.getWidth(), replacement)
+                );
+              }
+            }
+          }
+        }
+      }
+
+      super.visitCallExpression(node);
+    }
+  };
+}
+
+function isValidForRule(node: ts.CallExpression, methodName: string, providerName: string): boolean {
+  const expression = node.expression;
+
+  if (
+    tsutils.isPropertyAccessExpression(expression) &&
+    expression.name.text === methodName &&
+    tsutils.isPropertyAccessExpression(expression.expression) &&
+    expression.expression.expression.kind === ts.SyntaxKind.ThisKeyword
+  ) {
+    const classNode = findDeclarativeClass(node);
+    const controllerName = expression.expression.name.text;
+
+    if (classNode) {
+      const constructorNode = classNode.members.find(n => tsutils.isConstructorDeclaration(n));
+
+      if (constructorNode && tsutils.isConstructorDeclaration(constructorNode)) {
+        const controllerParameter = constructorNode.parameters.find(
+          p => tsutils.isTypeReferenceNode(p.type) && tsutils.isIdentifier(p.name) && p.name.text === controllerName
+        );
+
+        if (
+          controllerParameter &&
+          tsutils.isTypeReferenceNode(controllerParameter.type) &&
+          tsutils.isIdentifier(controllerParameter.type.typeName) &&
+          controllerParameter.type.typeName.text === providerName
+        ) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+function findDeclarativeClass(node: ts.Node): ts.ClassDeclaration | undefined {
+  if (!node) {
+    return;
+  }
+
+  if (tsutils.isClassDeclaration(node)) {
+    return node;
+  }
+
+  return findDeclarativeClass(node.parent);
+}

--- a/src/ionActionSheetMethodCreateParametersRenamedRule.ts
+++ b/src/ionActionSheetMethodCreateParametersRenamedRule.ts
@@ -1,5 +1,5 @@
 import * as Lint from 'tslint';
-import { IOptions, Replacement } from 'tslint';
+import { Replacement } from 'tslint';
 import * as ts from 'typescript';
 
 export const ruleName = 'ion-action-sheet-method-create-parameters-renamed';
@@ -8,23 +8,23 @@ export const ruleName = 'ion-action-sheet-method-create-parameters-renamed';
  * This rule helps with the conversion of the ActionSheetController API.
  */
 class ActionSheetMethodCreateParametersRenamedWalker extends Lint.RuleWalker {
-  //actionControllerVariableName = undefined;
-  foundPropertyArray = [];
+  private details = {
+    actionControllerVariableName: '',
+    foundPropertyArray: []
+  };
 
-  // TODO: Not sure if we need to track the name of the ActionSheetController variable.
-  // visitConstructorDeclaration(node: ts.ConstructorDeclaration) {
-  //   debugger;
-  //   for (let element of node.parameters) {
-  //     const typeName = (element.type as any).typeName.text;
-  //     if (typeName === 'ActionSheetController') {
-  //       this.actionControllerVariableName = (element.name as any).text;
-  //       this.tryAddFailure();
-  //       break;
-  //     }
-  //   }
+  visitConstructorDeclaration(node: ts.ConstructorDeclaration) {
+    debugger;
 
-  //   super.visitConstructorDeclaration(node);
-  // }
+    for (let element of node.parameters) {
+      const typeName = element.type.getFullText().trim();
+      if (typeName === 'ActionSheetController') {
+        this.details.actionControllerVariableName = (element.name as any).escapedText;
+        this.tryAddFailure();
+        break;
+      }
+    }
+  }
 
   visitCallExpression(node: ts.CallExpression) {
     const expression = node.expression as any;
@@ -37,7 +37,7 @@ class ActionSheetMethodCreateParametersRenamedWalker extends Lint.RuleWalker {
           case 'title':
           case 'subTitle':
             argument.parentVariableName = (node.expression as any).expression.text;
-            this.foundPropertyArray.push(argument);
+            this.details.foundPropertyArray.push(argument);
             this.tryAddFailure();
             break;
         }
@@ -46,21 +46,26 @@ class ActionSheetMethodCreateParametersRenamedWalker extends Lint.RuleWalker {
   }
 
   private tryAddFailure() {
-    for (let i = this.foundPropertyArray.length - 1; i >= 0; i--) {
-      let argument = this.foundPropertyArray[i];
+    // Don't process until the actionControllerVariableName has been found
+
+    if (!this.details.actionControllerVariableName) {
+      return;
+    }
+
+    for (let i = this.details.foundPropertyArray.length - 1; i >= 0; i--) {
+      let argument = this.details.foundPropertyArray[i];
 
       const replacementParam = argument.name.text === 'title' ? 'header' : 'subHeader';
 
-      // TODO: Determine if this needs to be added in later.
-      //if (this.actionControllerVariableName && this.actionControllerVariableName === argument.parentVariableName) {
-      const errorMessage = `The ${argument.name.text} field has been replaced by ${replacementParam}.`;
+      console.log(this.details.actionControllerVariableName, argument.parentVariableName);
+      if (this.details.actionControllerVariableName && this.details.actionControllerVariableName === argument.parentVariableName) {
+        const errorMessage = `The ${argument.name.text} field has been replaced by ${replacementParam}.`;
 
-      const replacement = new Replacement(argument.name.getStart(), argument.name.getWidth(), replacementParam);
+        const replacement = new Replacement(argument.name.getStart(), argument.name.getWidth(), replacementParam);
 
-      this.addFailure(this.createFailure(argument.name.getStart(), argument.name.getWidth(), errorMessage, [replacement]));
-      this.foundPropertyArray.splice(i, 1);
-
-      //}
+        this.addFailure(this.createFailure(argument.name.getStart(), argument.name.getWidth(), errorMessage, [replacement]));
+        this.details.foundPropertyArray.splice(i, 1);
+      }
     }
   }
 }

--- a/src/ionActionSheetMethodCreateParametersRenamedRule.ts
+++ b/src/ionActionSheetMethodCreateParametersRenamedRule.ts
@@ -1,74 +1,12 @@
 import * as Lint from 'tslint';
-import { Replacement } from 'tslint';
 import * as ts from 'typescript';
+
+import { createParametersRenamedClass } from './helpers/parametersRenamed';
 
 export const ruleName = 'ion-action-sheet-method-create-parameters-renamed';
 
-/**
- * This rule helps with the conversion of the ActionSheetController API.
- */
-class ActionSheetMethodCreateParametersRenamedWalker extends Lint.RuleWalker {
-  private details = {
-    actionControllerVariableName: '',
-    foundPropertyArray: []
-  };
-
-  visitConstructorDeclaration(node: ts.ConstructorDeclaration) {
-    debugger;
-
-    for (let element of node.parameters) {
-      const typeName = element.type.getFullText().trim();
-      if (typeName === 'ActionSheetController') {
-        this.details.actionControllerVariableName = (element.name as any).escapedText;
-        this.tryAddFailure();
-        break;
-      }
-    }
-  }
-
-  visitCallExpression(node: ts.CallExpression) {
-    const expression = node.expression as any;
-
-    if (expression.name && expression.name.text === 'create') {
-      for (let argument of (node.arguments[0] as any).properties) {
-        const name = argument.name.text;
-
-        switch (name) {
-          case 'title':
-          case 'subTitle':
-            argument.parentVariableName = (node.expression as any).expression.text;
-            this.details.foundPropertyArray.push(argument);
-            this.tryAddFailure();
-            break;
-        }
-      }
-    }
-  }
-
-  private tryAddFailure() {
-    // Don't process until the actionControllerVariableName has been found
-
-    if (!this.details.actionControllerVariableName) {
-      return;
-    }
-
-    for (let i = this.details.foundPropertyArray.length - 1; i >= 0; i--) {
-      let argument = this.details.foundPropertyArray[i];
-
-      const replacementParam = argument.name.text === 'title' ? 'header' : 'subHeader';
-
-      console.log(this.details.actionControllerVariableName, argument.parentVariableName);
-      if (this.details.actionControllerVariableName && this.details.actionControllerVariableName === argument.parentVariableName) {
-        const errorMessage = `The ${argument.name.text} field has been replaced by ${replacementParam}.`;
-
-        const replacement = new Replacement(argument.name.getStart(), argument.name.getWidth(), replacementParam);
-
-        this.addFailure(this.createFailure(argument.name.getStart(), argument.name.getWidth(), errorMessage, [replacement]));
-        this.details.foundPropertyArray.splice(i, 1);
-      }
-    }
-  }
-}
+const parameterMap = new Map([['title', 'header'], ['subTitle', 'subHeader']]);
+const Walker = createParametersRenamedClass('create', 'ActionSheetController', parameterMap);
 
 export class Rule extends Lint.Rules.AbstractRule {
   public static metadata: Lint.IRuleMetadata = {
@@ -82,6 +20,6 @@ export class Rule extends Lint.Rules.AbstractRule {
   };
 
   public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-    return this.applyWithWalker(new ActionSheetMethodCreateParametersRenamedWalker(sourceFile, this.getOptions()));
+    return this.applyWithWalker(new Walker(sourceFile, this.getOptions()));
   }
 }

--- a/src/ionAlertMethodCreateParametersRenamedRule.ts
+++ b/src/ionAlertMethodCreateParametersRenamedRule.ts
@@ -1,74 +1,12 @@
 import * as Lint from 'tslint';
-import { Replacement } from 'tslint';
 import * as ts from 'typescript';
+
+import { createParametersRenamedClass } from './helpers/parametersRenamed';
 
 export const ruleName = 'ion-alert-method-create-parameters-renamed';
 
-/**
- * This rule helps with the conversion of the AlertController API.
- */
-class AlertMethodCreateParametersRenamedWalker extends Lint.RuleWalker {
-  private details = {
-    actionControllerVariableName: '',
-    foundPropertyArray: []
-  };
-
-  visitConstructorDeclaration(node: ts.ConstructorDeclaration) {
-    debugger;
-
-    for (let element of node.parameters) {
-      const typeName = element.type.getFullText().trim();
-      if (typeName === 'AlertController') {
-        this.details.actionControllerVariableName = (element.name as any).escapedText;
-        this.tryAddFailure();
-        break;
-      }
-    }
-  }
-
-  visitCallExpression(node: ts.CallExpression) {
-    const expression = node.expression as any;
-
-    if (expression.name && expression.name.text === 'create') {
-      for (let argument of (node.arguments[0] as any).properties) {
-        const name = argument.name.text;
-
-        switch (name) {
-          case 'title':
-          case 'subTitle':
-            argument.parentVariableName = (node.expression as any).expression.text;
-            this.details.foundPropertyArray.push(argument);
-            this.tryAddFailure();
-            break;
-        }
-      }
-    }
-  }
-
-  private tryAddFailure() {
-    // Don't process until the actionControllerVariableName has been found
-
-    if (!this.details.actionControllerVariableName) {
-      return;
-    }
-
-    for (let i = this.details.foundPropertyArray.length - 1; i >= 0; i--) {
-      let argument = this.details.foundPropertyArray[i];
-
-      const replacementParam = argument.name.text === 'title' ? 'header' : 'subHeader';
-
-      console.log(this.details.actionControllerVariableName, argument.parentVariableName);
-      if (this.details.actionControllerVariableName && this.details.actionControllerVariableName === argument.parentVariableName) {
-        const errorMessage = `The ${argument.name.text} field has been replaced by ${replacementParam}.`;
-
-        const replacement = new Replacement(argument.name.getStart(), argument.name.getWidth(), replacementParam);
-
-        this.addFailure(this.createFailure(argument.name.getStart(), argument.name.getWidth(), errorMessage, [replacement]));
-        this.details.foundPropertyArray.splice(i, 1);
-      }
-    }
-  }
-}
+const parameterMap = new Map([['title', 'header'], ['subTitle', 'subHeader']]);
+const Walker = createParametersRenamedClass('create', 'AlertController', parameterMap);
 
 export class Rule extends Lint.Rules.AbstractRule {
   public static metadata: Lint.IRuleMetadata = {
@@ -82,6 +20,6 @@ export class Rule extends Lint.Rules.AbstractRule {
   };
 
   public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-    return this.applyWithWalker(new AlertMethodCreateParametersRenamedWalker(sourceFile, this.getOptions()));
+    return this.applyWithWalker(new Walker(sourceFile, this.getOptions()));
   }
 }

--- a/test/ionActionSheetMethodCreateParametersRenamed.spec.ts
+++ b/test/ionActionSheetMethodCreateParametersRenamed.spec.ts
@@ -22,6 +22,25 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source);
     });
 
+    it('should not be triggered if the type is not ActionSheetController', () => {
+      debugger;
+
+      let source = `
+      class DoSomething{
+        constructor(private actionSheetCtrl: SomeOtherController){}
+
+        function showActionSheet(){
+          const actionSheet = await actionSheetCtrl.create({
+            title: 'This is the title',
+            subTitle: 'this is the sub title'
+          });
+          await actionSheet.present();
+        }
+      }
+        `;
+      assertSuccess(ruleName, source);
+    });
+
     it('should work with different names for the ActionSheetController object', () => {
       let source = `
       class DoSomething{
@@ -44,7 +63,9 @@ describe(ruleName, () => {
     it('should fail when title is passed in', () => {
       let source = `
       class DoSomething{
-        constructor(private actionSheetCtrl: ActionSheetController){}
+        constructor(private actionSheetCtrl: ActionSheetController){
+
+        }
 
         function showActionSheet(){
           const actionSheet = await actionSheetCtrl.create({
@@ -77,29 +98,6 @@ describe(ruleName, () => {
           });
           await actionSheet.present();
         }
-      }
-          `;
-
-      assertAnnotated({
-        ruleName,
-        message: 'The subTitle field has been replaced by subHeader.',
-        source
-      });
-    });
-
-    it('should fail no matter where the constructor is placed in code', () => {
-      let source = `
-      class DoSomething{
-        function showActionSheet(){
-          const actionSheet = await actionSheetCtrl.create({
-            header: 'This is the title',            
-            subTitle: 'this is the sub title'            
-            ~~~~~~~~
-          });
-          await actionSheet.present();
-        }
-
-        constructor(private actionSheetCtrl: ActionSheetController){}
       }
           `;
 

--- a/test/ionAlertMethodCreateParametersRenamed.spec.ts
+++ b/test/ionAlertMethodCreateParametersRenamed.spec.ts
@@ -22,6 +22,25 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source);
     });
 
+    it('should not be triggered if the type is not AlertController', () => {
+      debugger;
+
+      let source = `
+      class DoSomething{
+        constructor(private actionSheetCtrl: SomeOtherController){}
+
+        function showActionSheet(){
+          const actionSheet = await actionSheetCtrl.create({
+            title: 'This is the title',
+            subTitle: 'this is the sub title'
+          });
+          await actionSheet.present();
+        }
+      }
+        `;
+      assertSuccess(ruleName, source);
+    });
+
     it('should work with different names for the AlertController object', () => {
       let source = `
       class DoSomething{
@@ -77,29 +96,6 @@ describe(ruleName, () => {
           });
           await alert.present();
         }
-      }
-          `;
-
-      assertAnnotated({
-        ruleName,
-        message: 'The subTitle field has been replaced by subHeader.',
-        source
-      });
-    });
-
-    it('should fail no matter where the constructor is placed in code', () => {
-      let source = `
-      class DoSomething{
-        function showAlert(){
-          const alert = await alertCtrl.create({
-            header: 'This is the title',            
-            subTitle: 'this is the sub title'            
-            ~~~~~~~~
-          });
-          await alert.present();
-        }
-
-        constructor(private alertCtrl: AlertController){}
       }
           `;
 

--- a/test/ionAlertMethodCreateParametersRenamed.spec.ts
+++ b/test/ionAlertMethodCreateParametersRenamed.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
-import { Replacement } from 'tslint';
+import { Replacement, Utils } from 'tslint';
 import { ruleName } from '../src/ionAlertMethodCreateParametersRenamedRule';
-import { assertAnnotated, assertSuccess } from './testHelper';
+import { assertAnnotated, assertFailures, assertSuccess } from './testHelper';
 
 describe(ruleName, () => {
   describe('success', () => {
@@ -10,8 +10,8 @@ describe(ruleName, () => {
       class DoSomething{
         constructor(private alertCtrl: AlertController){}
 
-        function showAlert(){
-          const alert = await alertCtrl.create({
+        showAlert(){
+          const alert = await this.alertCtrl.create({
             header: 'This is the title',
             subHeader: 'this is the sub title'
           });
@@ -23,14 +23,12 @@ describe(ruleName, () => {
     });
 
     it('should not be triggered if the type is not AlertController', () => {
-      debugger;
-
       let source = `
       class DoSomething{
         constructor(private actionSheetCtrl: SomeOtherController){}
 
-        function showActionSheet(){
-          const actionSheet = await actionSheetCtrl.create({
+        showActionSheet(){
+          const actionSheet = await this.actionSheetCtrl.create({
             title: 'This is the title',
             subTitle: 'this is the sub title'
           });
@@ -44,10 +42,10 @@ describe(ruleName, () => {
     it('should work with different names for the AlertController object', () => {
       let source = `
       class DoSomething{
-        constructor(private myOtherNamedalertCtrl: AlertController){}
+        constructor(private myOtherNamedCtrl: AlertController){}
 
-        function showAlert(){
-          const alert = await myOtherNamedalertCtrl.create({
+        showAlert(){
+          const alert = await this.myOtherNamedCtrl.create({
             header: 'This is the title',
             subHeader: 'this is the sub title'
           });
@@ -65,8 +63,8 @@ describe(ruleName, () => {
       class DoSomething{
         constructor(private alertCtrl: AlertController){}
 
-        function showAlert(){
-          const alert = await alertCtrl.create({
+        showAlert(){
+          const alert = await this.alertCtrl.create({
             title: 'This is the title',
             ~~~~~
             subTitle: 'this is the sub title'            
@@ -78,7 +76,7 @@ describe(ruleName, () => {
 
       assertAnnotated({
         ruleName,
-        message: 'The title field has been replaced by header.',
+        message: 'Property title has been renamed to header.',
         source
       });
     });
@@ -88,8 +86,8 @@ describe(ruleName, () => {
       class DoSomething{
         constructor(private alertCtrl: AlertController){}
 
-        function showAlert(){
-          const alert = await alertCtrl.create({
+        showAlert(){
+          const alert = await this.alertCtrl.create({
             header: 'This is the title',            
             subTitle: 'this is the sub title'            
             ~~~~~~~~
@@ -101,47 +99,64 @@ describe(ruleName, () => {
 
       assertAnnotated({
         ruleName,
-        message: 'The subTitle field has been replaced by subHeader.',
+        message: 'Property subTitle has been renamed to subHeader.',
         source
       });
     });
   });
 
   describe('replacements', () => {
-    it('should fail when navbar is passed in', () => {
+    it('should replace multiple', () => {
       let source = `
       class DoSomething{
         constructor(private alertCtrl: AlertController){}
 
-        function showAlert(){
-          const alert = await alertCtrl.create({
-            header: 'This is the title',            
+        showAlert(){
+          const alert = await this.alertCtrl.create({
+            title: 'This is the title',            
             subTitle: 'this is the sub title'
-            ~~~~~~~~
           });
           await alert.present();
         }
       }
           `;
 
-      const failures = assertAnnotated({
-        ruleName,
-        message: 'The subTitle field has been replaced by subHeader.',
-        source
-      });
+      const failures = assertFailures(ruleName, source, [
+        {
+          message: 'Property title has been renamed to header.',
+          startPosition: {
+            line: 6,
+            character: 12
+          },
+          endPosition: {
+            line: 6,
+            character: 17
+          }
+        },
+        {
+          message: 'Property subTitle has been renamed to subHeader.',
+          startPosition: {
+            line: 7,
+            character: 12
+          },
+          endPosition: {
+            line: 7,
+            character: 20
+          }
+        }
+      ]);
 
-      const fixes: Replacement[] = failures[0].getFix() as any;
+      const fixes = failures.map(f => f.getFix());
+      const res = Replacement.applyAll(source, Utils.flatMap(fixes, Utils.arrayify));
 
-      const res = Replacement.applyAll(source, fixes);
       expect(res).to.eq(`
       class DoSomething{
         constructor(private alertCtrl: AlertController){}
 
-        function showAlert(){
-          const alert = await alertCtrl.create({
+        showAlert(){
+          const alert = await this.alertCtrl.create({
             header: 'This is the title',            
             subHeader: 'this is the sub title'
-            ~~~~~~~~
           });
           await alert.present();
         }


### PR DESCRIPTION
@cwoolum Here's an alternative to https://github.com/ionic-team/v4-migration-tslint/pull/21 which doesn't use state within the rule walker

It also should work no matter where the constructor is defined because it looks it up

EDIT: also, it shouldn't throw errors when a different syntax is encountered (like in https://github.com/ionic-team/v4-migration-tslint/issues/22), because it validates a very specific syntax