### PR TITLE
Feature create/present should use await rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,9 @@ We are looking for contributors to help build these rules out! See [`CONTRIBUTIN
 
 1.  Add a file called `ionic-migration.json` at the root of your project and paste in the following JSON.
 
-    ```
+    ```json
     {
-      "rulesDirectory": [
-        "@ionic/v4-migration-tslint/rules"
-      ],
+      "rulesDirectory": ["@ionic/v4-migration-tslint/rules"],
       "rules": {
         "ion-action-sheet-method-create-parameters-renamed": true,
         "ion-alert-method-create-parameters-renamed": true,
@@ -46,7 +44,7 @@ We are looking for contributors to help build these rules out! See [`CONTRIBUTIN
 
 1.  Lint your project:
 
-    ```
+    ```bash
     npx tslint -c ionic-migration.json -p tsconfig.json
     ```
 
@@ -147,11 +145,11 @@ We are looking for contributors to help build these rules out! See [`CONTRIBUTIN
       <a href="https://github.com/ionic-team/ionic/blob/master/angular/BREAKING.md#overlays">Overlays</a>
     </th>
     <td></td>
-    <td>:white_large_square:</td>
+    <td>:white_check_mark:</td>
     <td>
       <code>ion-overlay-method-create-should-use-await</code>
     </td>
-    <td></td>
+    <td><a href="https://github.com/cwoolum">@cwoolum</a></td>
   </tr>
   <tr>
     <td></td>

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ We are looking for contributors to help build these rules out! See [`CONTRIBUTIN
         "ion-alert-method-create-parameters-renamed": true,
         "ion-datetime-capitalization-changed": true,
         "ion-item-option-method-get-sliding-percent-renamed": true,
+        "ion-overlay-method-create-should-use-await": true,
+        "ion-overlay-method-present-should-use-await": true,
         "ion-back-button-not-added-by-default": { "options": [true], "severity": "warning" },
         "ion-button-attributes-renamed": true,
         "ion-button-is-now-an-element": true,
@@ -144,7 +146,7 @@ We are looking for contributors to help build these rules out! See [`CONTRIBUTIN
     <th rowspan="2">
       <a href="https://github.com/ionic-team/ionic/blob/master/angular/BREAKING.md#overlays">Overlays</a>
     </th>
-    <td></td>
+    <td>:wrench:</td>
     <td>:white_check_mark:</td>
     <td>
       <code>ion-overlay-method-create-should-use-await</code>
@@ -153,11 +155,11 @@ We are looking for contributors to help build these rules out! See [`CONTRIBUTIN
   </tr>
   <tr>
     <td></td>
-    <td>:white_large_square:</td>
+    <td>:white_check_mark:</td>
     <td>
       <code>ion-overlay-method-present-should-use-await</code>
     </td>
-    <td></td>
+     <td><a href="https://github.com/cwoolum">@cwoolum</a></td>
   </tr>
   <tr>
     <th colspan="5">Markup Changes</th>

--- a/src/helpers/parametersRenamed.ts
+++ b/src/helpers/parametersRenamed.ts
@@ -1,6 +1,6 @@
 import * as Lint from 'tslint';
-import * as ts from 'typescript';
 import * as tsutils from 'tsutils';
+import * as ts from 'typescript';
 
 /**
  * Currently only supports a call exactly like this:
@@ -46,7 +46,7 @@ export function createParametersRenamedClass(methodName: string, providerName: s
   };
 }
 
-function isValidForRule(node: ts.CallExpression, methodName: string, providerName: string): boolean {
+export function isValidForRule(node: ts.CallExpression, methodName: string, ...providerNames: string[]): boolean {
   const expression = node.expression;
 
   if (
@@ -70,7 +70,7 @@ function isValidForRule(node: ts.CallExpression, methodName: string, providerNam
           controllerParameter &&
           tsutils.isTypeReferenceNode(controllerParameter.type) &&
           tsutils.isIdentifier(controllerParameter.type.typeName) &&
-          controllerParameter.type.typeName.text === providerName
+          providerNames.indexOf(controllerParameter.type.typeName.text) > -1
         ) {
           return true;
         }

--- a/src/ionOverlayMethodCreateShouldUseAwaitRule.ts
+++ b/src/ionOverlayMethodCreateShouldUseAwaitRule.ts
@@ -1,0 +1,48 @@
+import * as Lint from 'tslint';
+import * as tsutils from 'tsutils';
+import * as ts from 'typescript';
+import { isValidForRule } from './helpers/parametersRenamed';
+export const ruleName = 'ion-overlay-method-create-should-use-await';
+export const ruleMessage = 'You must await the create method';
+
+const matchingControllers = [
+  'PopoverController',
+  'ModalController',
+  'ActionSheetController',
+  'LoadingController',
+  'ToastController',
+  'AlertController'
+];
+
+class CreateMethodShouldUseAwaitWalker extends Lint.RuleWalker {
+  visitCallExpression(node: ts.CallExpression) {
+    debugger;
+    if (node.arguments.length > 0) {
+      const firstArgument = node.arguments[0];
+
+      if (isValidForRule(node, 'create', ...matchingControllers) && tsutils.isObjectLiteralExpression(firstArgument)) {
+        if (node.parent.kind !== ts.SyntaxKind.AwaitExpression) {
+          this.addFailureAtNode(node, ruleMessage, Lint.Replacement.replaceFromTo(node.getStart(), node.getStart(), 'await '));
+        }
+      }
+    }
+
+    super.visitCallExpression(node);
+  }
+}
+
+export class Rule extends Lint.Rules.AbstractRule {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: ruleName,
+    type: 'functionality',
+    description: 'You must await the create method for the following controllers: ' + matchingControllers.join(', '),
+    options: null,
+    optionsDescription: 'Not configurable.',
+    typescriptOnly: true,
+    hasFix: true
+  };
+
+  public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    return this.applyWithWalker(new CreateMethodShouldUseAwaitWalker(sourceFile, this.getOptions()));
+  }
+}

--- a/src/ionOverlayMethodPresentShouldUseAwaitRule.ts
+++ b/src/ionOverlayMethodPresentShouldUseAwaitRule.ts
@@ -1,0 +1,46 @@
+import * as Lint from 'tslint';
+import * as tsutils from 'tsutils';
+import * as ts from 'typescript';
+export const ruleName = 'ion-overlay-method-present-should-use-await';
+export const ruleMessage = 'You must await the present method';
+
+const matchingControllers = [
+  'PopoverController',
+  'ModalController',
+  'ActionSheetController',
+  'LoadingController',
+  'ToastController',
+  'AlertController'
+];
+
+class CreateMethodShouldUseAwaitWalker extends Lint.RuleWalker {
+  visitCallExpression(node: ts.CallExpression) {
+    debugger;
+
+    let expression = node.expression;
+
+    if (tsutils.isPropertyAccessExpression(expression) && expression.name.text === 'present') {
+      if (node.parent.kind !== ts.SyntaxKind.AwaitExpression) {
+        this.addFailureAtNode(node, ruleMessage);
+      }
+    }
+
+    super.visitCallExpression(node);
+  }
+}
+
+export class Rule extends Lint.Rules.AbstractRule {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: ruleName,
+    type: 'functionality',
+    description: 'You must await the present method for the following controllers: ' + matchingControllers.join(', '),
+    options: null,
+    optionsDescription: 'Not configurable.',
+    typescriptOnly: true,
+    hasFix: true
+  };
+
+  public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    return this.applyWithWalker(new CreateMethodShouldUseAwaitWalker(sourceFile, this.getOptions()));
+  }
+}

--- a/test/ionOverlayMethodCreateShouldUseAwaitRule.spec.ts
+++ b/test/ionOverlayMethodCreateShouldUseAwaitRule.spec.ts
@@ -1,0 +1,134 @@
+import { expect } from 'chai';
+import { Replacement, RuleFailure, Utils } from '../node_modules/tslint';
+import { ruleMessage, ruleName } from '../src/ionOverlayMethodCreateShouldUseAwaitRule';
+import { assertAnnotated, assertSuccess } from './testHelper';
+
+describe(ruleName, () => {
+  describe('success', () => {
+    it('should work when await exists in front of the create method', () => {
+      let source = `
+      class DoSomething{
+        constructor(private actionSheetController: ActionSheetController){}
+        
+        doWork(){
+          await this.actionSheetController.create({
+            component: PopoverComponent,
+            ev: event,
+            translucent: true
+          })
+        }
+      }
+        `;
+      assertSuccess(ruleName, source);
+    });
+
+    it('should not do anything if the class name does not match', () => {
+      let source = `
+      class DoSomething{
+        constructor(private someOtherController: SomeOtherController){}
+        
+        doWork(){
+          await this.someOtherController.create({
+            component: PopoverComponent,
+            ev: event,
+            translucent: true
+          })
+        }
+      }
+        `;
+      assertSuccess(ruleName, source);
+    });
+  });
+
+  const controllersList = [
+    'ActionSheetController',
+    'AlertController',
+    'LoadingController',
+    'ModalController',
+    'PopoverController',
+    'ToastController'
+  ];
+
+  for (let controller of controllersList) {
+    describe(controller, () => {
+      describe('failure', () => {
+        it('should fail if await is not present', () => {
+          let source = `
+      class DoSomething{
+        constructor(private actionSheetController: ${controller}){}
+        
+        doWork(){
+          this.actionSheetController.create({
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            component: PopoverComponent,
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            ev: event,
+            ~~~~~~~~~~
+            translucent: true
+            ~~~~~~~~~~~~~~~~~
+          })
+          ~~
+        }
+      }
+        `;
+          assertAnnotated({
+            ruleName,
+            message: ruleMessage,
+            source
+          });
+        });
+      });
+
+      describe('replacements', () => {
+        it('should replace multiple', () => {
+          let source = `
+      class DoSomething{
+        constructor(private actionSheetController: ${controller}){}
+        
+        doWork(){
+          this.actionSheetController.create({
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            component: PopoverComponent,
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            ev: event,
+            ~~~~~~~~~~
+            translucent: true
+            ~~~~~~~~~~~~~~~~~
+          })
+          ~~
+        }
+      }
+          `;
+
+          let failures = assertAnnotated({
+            ruleName,
+            message: ruleMessage,
+            source
+          });
+
+          const fixes = (failures as RuleFailure[]).map(f => f.getFix());
+          const res = Replacement.applyAll(source, Utils.flatMap(fixes, Utils.arrayify));
+
+          expect(res).to.eq(`
+      class DoSomething{
+        constructor(private actionSheetController: ${controller}){}
+        
+        doWork(){
+          await this.actionSheetController.create({
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            component: PopoverComponent,
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            ev: event,
+            ~~~~~~~~~~
+            translucent: true
+            ~~~~~~~~~~~~~~~~~
+          })
+          ~~
+        }
+      }
+          `);
+        });
+      });
+    });
+  }
+});

--- a/test/ionOverlayMethodPresentShouldUseAwaitRule.spec.ts
+++ b/test/ionOverlayMethodPresentShouldUseAwaitRule.spec.ts
@@ -1,0 +1,51 @@
+import { ruleMessage, ruleName } from '../src/ionOverlayMethodPresentShouldUseAwaitRule';
+import { assertAnnotated, assertSuccess } from './testHelper';
+
+describe(ruleName, () => {
+  describe('success', () => {
+    it('should work when await exists in front of the present method', () => {
+      let source = `
+      class DoSomething{
+        constructor(private actionSheetController: ActionSheetController){}
+        
+        doWork(){
+          var ctrl = await this.actionSheetController.create({
+            component: PopoverComponent,
+            ev: event,
+            translucent: true
+          });
+
+          await ctrl.present();
+        }
+      }
+        `;
+      assertSuccess(ruleName, source);
+    });
+  });
+
+  describe('failure', () => {
+    it('should fail if await is not present', () => {
+      let source = `
+      class DoSomething{
+        constructor(private actionSheetController: ActionSheetController){}
+        
+        doWork(){
+          var ctrl = this.actionSheetController.create({
+            component: PopoverComponent,
+            ev: event,
+            translucent: true
+          });
+
+          ctrl.present();
+          ~~~~~~~~~~~~~~
+        }
+      }
+        `;
+      assertAnnotated({
+        ruleName,
+        message: ruleMessage,
+        source
+      });
+    });
+  });
+});


### PR DESCRIPTION
@dwieeb, the `create` part of this PR is good but with `present` there is a problem. It seems that you cannot determine the type of an IdentityNode so there is no way to check that present if being executed against an Overlay or not. I decided not to add a fixer on `present` for that reason so the user can determine whether or not the rule applies.