### PR TITLE
fix(ion-button): Add a shape="round" attribute rule to ion-button

### DIFF
--- a/src/ionButtonAttributesRenamedRule.ts
+++ b/src/ionButtonAttributesRenamedRule.ts
@@ -17,7 +17,8 @@ const replacementMap = new Map([
   ['outline', 'fill="outline"'],
   ['solid', 'fill="solid"'],
   ['full', 'expand="full"'],
-  ['block', 'expand="block"']
+  ['block', 'expand="block"'],
+  ['round', 'shape="round"']
 ]);
 
 const IonButtonAttributesAreRenamedTemplateVisitor = createAttributesRenamedTemplateVisitorClass(['ion-button'], replacementMap);

--- a/test/ionButtonAttributesRenamed.spec.ts
+++ b/test/ionButtonAttributesRenamed.spec.ts
@@ -203,6 +203,23 @@ describe(ruleName, () => {
         source
       });
     });
+
+    it('should fail when round is used', () => {
+      let source = `
+      @Component({
+        template: \`
+          <ion-button round></ion-button>\`
+                      ~~~~~
+      })
+      class Bar{}
+          `;
+
+      assertAnnotated({
+        ruleName,
+        message: 'The round attribute of ion-button has been renamed. Use shape="round" instead.',
+        source
+      });
+    });
   });
 
   describe('replacements', () => {
@@ -594,6 +611,42 @@ describe(ruleName, () => {
       let expected = `
         @Component({
           template: \`<ion-button expand="block"></ion-button>
+          \`
+        })
+        class Bar {}
+      `;
+
+      expect(res).to.eq(expected);
+    });
+
+    it('should replace round with shape="round"', () => {
+      let source = `
+        @Component({
+          template: \`<ion-button round></ion-button>
+          \`
+        })
+        class Bar {}
+      `;
+
+      const fail = {
+        message: 'The round attribute of ion-button has been renamed. Use shape="round" instead.',
+        startPosition: {
+          line: 2,
+          character: 33
+        },
+        endPosition: {
+          line: 2,
+          character: 38
+        }
+      };
+
+      const failures = assertFailure(ruleName, source, fail);
+      const fixes = failures.map(f => f.getFix());
+      const res = Replacement.applyAll(source, Utils.flatMap(fixes, Utils.arrayify));
+
+      let expected = `
+        @Component({
+          template: \`<ion-button shape="round"></ion-button>
           \`
         })
         class Bar {}


### PR DESCRIPTION
On ion-button element the use of round attribute is now used under the shape attribute. This commit
adds one more rule to the ion-button-attributes-renamed with its relevant tests.

fix #100